### PR TITLE
Fix flag being captured on match start

### DIFF
--- a/ctf_flag/flag_func.lua
+++ b/ctf_flag/flag_func.lua
@@ -178,8 +178,15 @@ ctf_flag = {
 	end,
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
+		local flag = ctf_flag.get(pos)
 		meta:set_string("infotext", "Unowned flag")
 		minetest.get_node_timer(pos):start(5)
+
+		if not flag then
+			return
+		end
+
+		flag.claimed = nil
 	end,
 	after_place_node = function(pos, placer)
 		local name = placer:get_player_name()


### PR DESCRIPTION
From my tests it seems to work.

**How to test:**
* Dump 'flag.claimed' in chat before you set the value to nil, and notice that the flag is never captured when a match starts