### PR TITLE
Add in-game staff channel

### DIFF
--- a/ctf_chat/init.lua
+++ b/ctf_chat/init.lua
@@ -409,3 +409,24 @@ minetest.registered_chatcommands["me"].func = function(name, param)
 
 	minetest.chat_send_all(name .. " " .. param)
 end
+
+minetest.register_chatcommand("s", {
+    params = "<msg>",
+    description = "Send a message on the staff channel",
+    privs = {kick=true},
+    func = function(name, param)
+    local staff = {}
+    for _, player in pairs(minetest.get_connected_players()) do
+        local toname = player:get_player_name()
+        if minetest.check_player_privs(toname, {kick=true}) then
+            table.insert(staff, toname)
+            minetest.chat_send_player(toname, minetest.colorize("#ff6600",
+                    "«" .. name .. "» " .. param))
+            minetest.log("action", "CHAT[STAFFCHANNEL]: <" .. name .. "> " .. param)
+		if minetest.global_exists("chatplus") then
+			chatplus.log("[STAFFCHANNEL]: <" .. name .. "> " .. param)
+		end
+        end
+    end
+end
+})


### PR DESCRIPTION
This PR would add an in-game staff channel by adding the `/s` command.
Not sure if you find it as useful as I do but it'd only be a small change anyway. A tad easier than switching to IRC or Discord.
Opinions and reviews welcome!